### PR TITLE
Remove link annotation rule that points to 404

### DIFF
--- a/style.css
+++ b/style.css
@@ -409,8 +409,6 @@ address {
 }
 
 
-a[href^="http"]::after { content: url("ext-link.svg"); }
-
 dt strong code, .legend code {
     padding: 3px;
     display: inline-block;


### PR DESCRIPTION
This has a really weird effect in stable Safari (that might be its own Interop issue) and doesn't really do anything aside from that.